### PR TITLE
Branch minor tweaks

### DIFF
--- a/source/amx/amx.c
+++ b/source/amx/amx.c
@@ -292,17 +292,6 @@ typedef enum {
   OP_NUM_OPCODES
 } OPCODE;
 
-#define USENAMETABLE(hdr) \
-                        ((hdr)->defsize==sizeof(AMX_FUNCSTUBNT))
-#define NUMENTRIES(hdr,field,nextfield) \
-                        (unsigned)(((hdr)->nextfield - (hdr)->field) / (hdr)->defsize)
-#define GETENTRY(hdr,table,index) \
-                        (AMX_FUNCPART *)((unsigned char*)(hdr) + (unsigned)(hdr)->table + (unsigned)index*(hdr)->defsize)
-#define GETENTRYNAME(hdr,entry) \
-                        ( USENAMETABLE(hdr) \
-                           ? (char *)((unsigned char*)(hdr) + (unsigned)((AMX_FUNCSTUBNT*)(entry))->nameofs) \
-                           : ((AMX_FUNCSTUB*)(entry))->name )
-
 #if !defined NDEBUG
   static int check_endian(void)
   {
@@ -4138,17 +4127,6 @@ int AMXAPI amx_Release(AMX *amx,cell amx_addr)
 #endif /* AMX_ALLOT */
 
 #if defined AMX_XXXSTRING || defined AMX_UTF8XXX
-
-#define CHARBITS        (8*sizeof(char))
-#if PAWN_CELL_SIZE==16
-  #define CHARMASK      (0xffffu << 8*(2-sizeof(char)))
-#elif PAWN_CELL_SIZE==32
-  #define CHARMASK      (0xffffffffuL << 8*(4-sizeof(char)))
-#elif PAWN_CELL_SIZE==64
-  #define CHARMASK      (0xffffffffffffffffuLL << 8*(8-sizeof(char)))
-#else
-  #error Unsupported cell size
-#endif
 
 int AMXAPI amx_StrLen(const cell *cstr, int *length)
 {

--- a/source/amx/amx.c
+++ b/source/amx/amx.c
@@ -781,8 +781,11 @@ static int amx_BrowseRelocate(AMX *amx)
     } /* switch */
   } /* for */
 
-  assert(sysreq_flg==0 || sysreq_flg==0x01 || sysreq_flg==0x02);
-
+  #if defined AMX_NO_MACRO_INSTR
+    assert(sysreq_flg==0 || sysreq_flg==0x01);
+  #else
+    assert(sysreq_flg==0 || sysreq_flg==0x01 || sysreq_flg==0x02 || sysreq_flg==0x03);
+  #endif
   #if defined JIT
     amx->code_size = getMaxCodeSize()*opcode_count + hdr->cod
                      + (hdr->stp - hdr->dat);

--- a/source/amx/amx.c
+++ b/source/amx/amx.c
@@ -1645,7 +1645,7 @@ int AMXAPI amx_Register(AMX *amx, const AMX_NATIVE_INFO *list, int number)
       /* this function is not yet located */
       funcptr=(list!=NULL) ? findfunction(GETENTRYNAME(hdr,func),list,number) : NULL;
       if (funcptr!=NULL)
-        func->address=(ucell)funcptr;
+        ((AMX_FUNCWIDE *)func)->address=funcptr;
       else
         err=AMX_ERR_NOTFOUND;
     } /* if */

--- a/source/amx/amx.h
+++ b/source/amx/amx.h
@@ -358,6 +358,28 @@ typedef struct tagAMX_HEADER {
   #define AMX_MAGIC     AMX_MAGIC_64
 #endif
 
+#define USENAMETABLE(hdr) \
+                        ((hdr)->defsize==sizeof(AMX_FUNCSTUBNT))
+#define NUMENTRIES(hdr,field,nextfield) \
+                        (unsigned)(((hdr)->nextfield - (hdr)->field) / (hdr)->defsize)
+#define GETENTRY(hdr,table,index) \
+                        (AMX_FUNCPART *)((unsigned char*)(hdr) + (unsigned)(hdr)->table + (unsigned)index*(hdr)->defsize)
+#define GETENTRYNAME(hdr,entry) \
+                        ( USENAMETABLE(hdr) \
+                           ? (char *)((unsigned char*)(hdr) + (unsigned)((AMX_FUNCSTUBNT*)(entry))->nameofs) \
+                           : ((AMX_FUNCSTUB*)(entry))->name )
+
+#define CHARBITS        (8*sizeof(char))
+#if PAWN_CELL_SIZE==16
+  #define CHARMASK      (0xffffu << 8*(2-sizeof(char)))
+#elif PAWN_CELL_SIZE==32
+  #define CHARMASK      (0xffffffffuL << 8*(4-sizeof(char)))
+#elif PAWN_CELL_SIZE==64
+  #define CHARMASK      (0xffffffffffffffffuLL << 8*(8-sizeof(char)))
+#else
+  #error Unsupported cell size
+#endif
+
 enum {
   AMX_ERR_NONE,
   /* reserve the first 15 error codes for exit codes of the abstract machine */

--- a/source/amx/amx.h
+++ b/source/amx/amx.h
@@ -263,7 +263,9 @@ typedef struct tagAMX_NATIVE_INFO {
 #define AMX_USERNUM     4
 #endif
 #define sEXPMAX         19      /* maximum name length for file version <= 6 */
-#define sNAMEMAX        31      /* maximum name length of symbol name */
+#ifndef sNAMEMAX
+  #define sNAMEMAX      31      /* maximum name length of symbol name */
+#endif
 
 typedef struct tagAMX_FUNCSTUB {
   ucell address         PACKED;

--- a/source/amx/amx.h
+++ b/source/amx/amx.h
@@ -275,6 +275,14 @@ typedef struct tagFUNCSTUBNT {
   uint32_t nameofs      PACKED;
 } AMX_FUNCSTUBNT;
 
+typedef struct tagFUNCPART {
+  ucell address         PACKED;
+} AMX_FUNCPART;
+
+typedef struct tagFUNCWIDE {
+  AMX_NATIVE address    PACKED;
+} AMX_FUNCWIDE;
+
 /* The AMX structure is the internal structure for many functions. Not all
  * fields are valid at all times; many fields are cached in local variables.
  */


### PR DESCRIPTION
<!--
Please ensure you have read the CONTRIBUTING.md document before submitting this
pull request. Requests that fail to follow enough of the guidelines will likely
be closed immediately with request to rectify the issues.

Never pull to `master` - always pull to `dev` or a relevant feature branch.
-->

**What this PR does / why we need it**:

A few changes:

1. Moves a couple of macros to amx.h instead of amx.c.  This is because they are currenlty copied in to `Script.cpp` and this is DRYer.

2. Add an `#ifdef` check for `sNAMEMAX` so that defining it from a build script is easier.

3. Removes `SYSREQ.D` and adjusts `SYSREQ.C` to support function pointers twice the width of a cell (i.e. can run 32-bit pawn on x64, by clobbering the native name as well as the native pointer in the header).

4. Fixes an assert to allow for both `SYSREQ.C` and `SYSREQ.N` in the same file.

**What kind of pull this is**:

<!--Replace [ ] with [x] to mark the checkbox-->

* [ ] A Bug Fix
* [x] A New Feature
* [ ] Some repository meta (documentation, etc)
* [ ] Other

**Additional Documentation**:

<!--
If your PR introduces a change that requires documentation, add it here so it can be added to the wiki.
Feel free to edit the wiki yourself once your PR has been accepted.
-->
