### PR TITLE
Fixed: random(max = 0) not returning 0 (zero)

### DIFF
--- a/source/amx/amxcore.c
+++ b/source/amx/amxcore.c
@@ -439,6 +439,8 @@ static cell AMX_NATIVE_CALL core_random(AMX *amx,const cell *params)
     #else
         cell value = abs(params[1]);
     #endif
+  
+    if(value <= 1) return 0;
 
     /* one-time initialization (or, mostly one-time) */
     #if !defined SN_TARGET_PS2 && !defined _WIN32_WCE && !defined __ICC430__


### PR DESCRIPTION
random(max = 0) returns an arbitrary number. This does not conform to the PAWN Language Guide (February 2024, p. 108), according to which it should return "a pseudo-random number in the range 0 ... max-1", which in this case should be 0 (zero).