### PR TITLE
fix windows github runner version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-windows:
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -20,7 +20,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DCMAKE_BUILD_TYPE=Release ../source/compiler -A Win32 -G "Visual Studio 16 2019" -DCMAKE_C_FLAGS="/D sNAMEMAX=63"
+          cmake -DCMAKE_BUILD_TYPE=Release ../source/compiler -A Win32 -G "Visual Studio 17 2022" -DCMAKE_C_FLAGS="/D sNAMEMAX=63"
           cmake --build . --config Release
 
       - name: Upload artifacts


### PR DESCRIPTION
Fixes CI after the last merged PR and failed build because of outdated github runner version.
Also VS version was bumped from 2019 to 2022.

**What kind of pull this is**:

<!--Replace [ ] with [x] to mark the checkbox-->

* [ ] A Bug Fix
* [ ] A New Feature
* [x] Some repository meta (documentation, etc)
* [ ] Other
