### PR TITLE
Fixes and corrections

### DIFF
--- a/include/file.inc
+++ b/include/file.inc
@@ -30,6 +30,9 @@ native File: fopen(const name[], filemode: mode = io_readwrite);
 native bool: fclose(File: handle);
 native File: ftemp();
 native bool: fremove(const name[]);
+native bool: fcopy(const source[], const target[]);
+native bool: frename(const oldname[], const newname[]);
+native bool: fcreatedir(const name[]);
 
 native       fwrite(File: handle, const string[]);
 native       fread(File: handle, string[], size = sizeof string, bool: pack = false);
@@ -42,3 +45,12 @@ native       fseek(File: handle, position = 0, seek_whence: whence = seek_start)
 native       flength(File: handle);
 native       fexist(const pattern[]);
 native bool: fmatch(name[], const pattern[], index = 0, size = sizeof name);
+native bool: fstat(name[], &size = 0, &timestamp = 0, &mode = 0, &inode = 0);
+native bool: fattrib(const name[], timestamp=0, attrib=0x0f);
+native       filecrc(const name[]);
+
+native       readcfg(const filename[]="", const section[]="", const key[], value[], size=sizeof value, const defvalue[]="", bool:pack=false);
+native       readcfgvalue(const filename[]="", const section[]="", const key[], defvalue=0);
+native bool: writecfg(const filename[]="", const section[]="", const key[], const value[]);
+native bool: writecfgvalue(const filename[]="", const section[]="", const key[], value);
+native bool: deletecfg(const filename[]="", const section[]="", const key[]="");

--- a/include/string.inc
+++ b/include/string.inc
@@ -12,6 +12,7 @@
 native strlen(const string[]);
 native strpack(dest[], const source[], maxlength=sizeof dest);
 native strunpack(dest[], const source[], maxlength=sizeof dest);
+native strcopy(dest[], const source[], maxlength=sizeof dest);
 native strcat(dest[], const source[], maxlength=sizeof dest);
 
 native strmid(dest[], const source[], start=0, end=cellmax, maxlength=sizeof dest);
@@ -32,4 +33,4 @@ native uuencode(dest[], const source[], numbytes, maxlength=sizeof dest);
 native memcpy(dest[], const source[], index=0, numbytes, maxlength=sizeof dest);
 
 stock bool: strequal(const string1[], const string2[], bool:ignorecase=false, length=cellmax)
-    return strcmp(string1, string2, ignorecase, length) == 0
+    return strcmp(string1, string2, ignorecase, length) == 0;

--- a/include/time.inc
+++ b/include/time.inc
@@ -13,7 +13,9 @@ native gettime(&hour=0, &minute=0, &second=0);
 native settime(hour=cellmin, minute=cellmin, second=cellmin);
 native getdate(&year=0, &month=0, &day=0);
 native setdate(year=cellmin, month=cellmin, day=cellmin);
+
 native settimestamp(seconds1970);
+native cvttimestamp(seconds1970, &year=0, &month=0, &day=0, &hour=0, &minute=0, &second=0);
 
 native settimer(milliseconds, bool: singleshot=false);
 native tickcount(&granularity=0);

--- a/readme.md
+++ b/readme.md
@@ -113,13 +113,13 @@ seems to be based on an older release of Pawn.
 [build_win]: https://ci.appveyor.com/project/Southclaws/compiler/branch/master
 [build_status_win]:
   https://ci.appveyor.com/api/projects/status/k112tbr1afrkif0n?svg=true
-[team]: https://github.com/pawn-lang/compiler/graphs/contributors
+[team]: https://github.com/openmultiplayer/compiler/graphs/contributors
 [original_readme]:
-  https://github.com/pawn-lang/compiler/tree/master/readme_compuphase.txt
-[issues]: https://github.com/pawn-lang/compiler/issues
+  https://github.com/openmultiplayer/compiler/tree/master/readme_compuphase.txt
+[issues]: https://github.com/openmultiplayer/compiler/issues
 [bugs]: https://github.com/pawn-lang/compiler/wiki/Known-compiler-bugs
 [new]: https://github.com/pawn-lang/compiler/wiki/What's-new
-[releases]: https://github.com/pawn-lang/compiler/releases
+[releases]: https://github.com/openmultiplayer/compiler/releases
 [artifacts]:
   https://ci.appveyor.com/project/Southclaws/compiler/branch/master/artifacts
 [compat]: https://github.com/pawn-lang/compiler/wiki/Compatibility-mode

--- a/source/amx/amx.c
+++ b/source/amx/amx.c
@@ -793,6 +793,7 @@ static int amx_BrowseRelocate(AMX *amx)
   #else
     assert(sysreq_flg==0 || sysreq_flg==0x01 || sysreq_flg==0x02 || sysreq_flg==0x03);
   #endif
+
   #if defined JIT
     amx->code_size = getMaxCodeSize()*opcode_count + hdr->cod
                      + (hdr->stp - hdr->dat);
@@ -1047,7 +1048,7 @@ int AMXAPI amx_Init(AMX *amx,void *program)
     hdr=(AMX_HEADER *)amx->base;
     numlibraries=NUMENTRIES(hdr,libraries,pubvars);
     for (i=0; i<numlibraries; i++) {
-      lib=(AMX_FUNCWIDE*)GETENTRY(hdr, libraries, i);
+      lib=(AMX_FUNCWIDE*)GETENTRY(hdr,libraries,i);
       libname[0]='\0';
       #if defined LINUX || defined __FreeBSD__ || defined __OpenBSD__
         if (root!=NULL && *root!='\0') {
@@ -1404,7 +1405,7 @@ int AMXAPI amx_FindNative(AMX* amx, const char* name, int* index)
   }
 
   /* not found, set to an invalid index, so amx_Exec() will fail */
-  *index = INT_MAX;
+  *index=INT_MAX;
   return AMX_ERR_NOTFOUND;
 }
 #endif /* AMX_XXXNATIVES */

--- a/source/amx/amx.c
+++ b/source/amx/amx.c
@@ -1775,7 +1775,7 @@ int AMXAPI amx_PushString(AMX *amx, cell *amx_addr, cell **phys_addr, const char
   assert(string!=NULL);
 
   #if defined AMX_ANSIONLY
-    length = strlen(string) + 1;
+    length = strlen(string);
   #else
     length = (use_wchar ? wcslen((const wchar_t*)string) : strlen(string));
   #endif

--- a/source/amx/amx.h
+++ b/source/amx/amx.h
@@ -203,7 +203,7 @@ extern  "C" {
 
 #if !defined PAWN_CELL_SIZE
   #if defined __64BIT__
-    #define PAWN_CELL_SIZE 64     /* by default, use 32-bit cells */
+    #define PAWN_CELL_SIZE 64     /* use 64-bit cells for 64-bit systems */
   #else
     #define PAWN_CELL_SIZE 32     /* by default, use 32-bit cells */
   #endif
@@ -244,9 +244,8 @@ typedef int (AMXAPI *AMX_IDLE)(struct tagAMX *amx, int AMXAPI Exec(struct tagAMX
 #endif
 
 #if defined _MSC_VER
-  #pragma warning(disable:4103)  /* disable warning message 4103 that complains
-                                  * about pragma pack in a header file */
   #pragma warning(disable:4100)  /* "'%$S' : unreferenced formal parameter" */
+  #pragma warning(disable:4103)  /* disable warning message 4103 that complains about pragma pack in a header file */
   #pragma warning(disable:4127)  /* "conditional expression is constant" (needed for static_assert) */
   #pragma warning(disable:4996)  /* POSIX name is deprecated */
 #elif defined __GNUC__

--- a/source/amx/amxcore.c
+++ b/source/amx/amxcore.c
@@ -283,7 +283,7 @@ static cell AMX_NATIVE_CALL core_tolower(AMX *amx,const cell *params)
   #endif
 }
 
-static cell AMX_NATIVE_CALL core_toupper(AMX *amx, const cell *params)
+static cell AMX_NATIVE_CALL core_toupper(AMX *amx,const cell *params)
 {
   (void)amx;
   #if (defined __WIN32__ || defined _WIN32 || defined WIN32) && !defined _WIN64
@@ -347,7 +347,7 @@ static cell AMX_NATIVE_CALL getproperty(AMX *amx,const cell *params)
   /* if list_finditem() found the value, store the name */
   if (item!=NULL && item->value==params[3] && strlen(name)==0) {
     amx_GetAddr(amx,params[4],&cstr);
-    amx_SetString(cstr,item->name,1,0, UNLIMITED);
+    amx_SetString(cstr,item->name,1,0,UNLIMITED);
   } /* if */
   free(name);
   return (item!=NULL) ? item->value : 0;

--- a/source/amx/amxfile.c
+++ b/source/amx/amxfile.c
@@ -975,7 +975,7 @@ static cell AMX_NATIVE_CALL n_flength(AMX *amx, const cell *params)
   }
 
   long l,c;
-  int fn = fileno(f);
+  int fn=fileno(f);
   if (params[1]&FILE_WRITEABLE_BIT) {
     /* writable, flush */
     fflush(f);
@@ -983,7 +983,7 @@ static cell AMX_NATIVE_CALL n_flength(AMX *amx, const cell *params)
     _commit(fn);
 #endif
   }
-  c=lseek(fn,0,SEEK_CUR); 
+  c=lseek(fn,0,SEEK_CUR); /* save the current position */
   l=lseek(fn,0,SEEK_END); /* return the file position at its end */
   fseek(f,c,SEEK_SET);   /* restore the file pointer */
   (void)amx;
@@ -1073,7 +1073,7 @@ static cell AMX_NATIVE_CALL n_fexist(AMX *amx, const cell *params)
   (void)amx;
   amx_StrParam(amx,params[1],name);
   if (name!=NULL && completename(fullname,name,sizearray(fullname))!=NULL)
-      r = !access(fullname, 0);
+    r = !access(fullname, 0);
   return r;
 }
 

--- a/source/amx/amxfile.c
+++ b/source/amx/amxfile.c
@@ -664,7 +664,7 @@ static cell AMX_NATIVE_CALL n_fwrite(AMX *amx, const cell *params)
   if ((ucell)*cptr>UNPACKEDMAX) {
     /* the string is packed, write it as an ASCII/ANSI string */
     if ((str=(char*)alloca(len + 1))!=NULL) {
-      amx_GetString(str,cptr,0,len);
+      amx_GetString(str,cptr,0,len+1);
       r=fputs(str,f);
     } /* if */
   } else {

--- a/source/amx/amxfloat.c
+++ b/source/amx/amxfloat.c
@@ -150,7 +150,6 @@ static cell AMX_NATIVE_CALL n_floatfract(AMX *amx,const cell *params)
     *   params[0] = number of bytes
     *   params[1] = float operand
     */
-
     REAL fA = amx_ctof(params[1]);
 
     if (fA >= 0.0)

--- a/source/amx/amxfloat.c
+++ b/source/amx/amxfloat.c
@@ -289,7 +289,7 @@ static cell AMX_NATIVE_CALL n_floatsin(AMX *amx,const cell *params)
     */
     REAL fA = amx_ctof(params[1]);
     fA = ToRadians(fA, params[2]);
-    fA = (float)sin(fA);
+    fA = (REAL)sin(fA);
     (void)amx;
     return amx_ftoc(fA);
 }
@@ -304,7 +304,7 @@ static cell AMX_NATIVE_CALL n_floatcos(AMX *amx,const cell *params)
     */
     REAL fA = amx_ctof(params[1]);
     fA = ToRadians(fA, params[2]);
-    fA = (float)cos(fA);
+    fA = (REAL)cos(fA);
     (void)amx;
     return amx_ftoc(fA);
 }
@@ -319,7 +319,7 @@ static cell AMX_NATIVE_CALL n_floattan(AMX *amx,const cell *params)
     */
     REAL fA = amx_ctof(params[1]);
     fA = ToRadians(fA, params[2]);
-    fA = (float)tan(fA);
+    fA = (REAL)tan(fA);
     (void)amx;
     return amx_ftoc(fA);
 }

--- a/source/amx/amxstring.c
+++ b/source/amx/amxstring.c
@@ -997,8 +997,8 @@ static cell AMX_NATIVE_CALL n_memcpy(AMX *amx,const cell *params)
     return 0;
   amx_GetAddr(amx,params[1],&cdest);
   amx_GetAddr(amx,params[2],&csrc);
-  pdest=(unsigned char*)cdest;
-  psrc=(unsigned char*)csrc+params[3];
+  pdest=(unsigned char*)cdest+params[3];
+  psrc=(unsigned char*)csrc;
   memmove(pdest,psrc,params[4]);
   return 1;
 }

--- a/source/amx/amxstring.c
+++ b/source/amx/amxstring.c
@@ -542,8 +542,8 @@ static cell AMX_NATIVE_CALL n_strins(AMX* amx, const cell* params)
   if (index > lenstr || index > maxlen)
     return amx_RaiseError(amx, AMX_ERR_NATIVE);
 
-  /* current string is empty (and the insertion point is zero), just make a copy */
   if (lenstr == 0) {
+    /* current string is empty (and the insertion point is zero), just make a copy */
     assert(index == 0);
 
     if (lensub > maxlen)
@@ -554,7 +554,7 @@ static cell AMX_NATIVE_CALL n_strins(AMX* amx, const cell* params)
     else
       amx_StrUnpack(cstr, csub, lensub);
     return 1;
-  }
+  } /* if */
 
   if (lenstr + lensub >= maxlen && index + lensub >= maxlen) {
     int max_substr = maxlen - index;
@@ -564,18 +564,18 @@ static cell AMX_NATIVE_CALL n_strins(AMX* amx, const cell* params)
         c = extractchar(csub, count, 0);
         ptr = packedptr(cstr, index + count);
         *ptr = (unsigned char)c;
-      }
+      } /* for */
       *(packedptr(cstr, maxlen)) = 0;
     } else {
       for (count = 0; count < max_substr; count++) {
         c = extractchar(csub, count, 0);
         cstr[index + count] = c;
-      }
+      } /* for */
       cstr[maxlen] = 0;
-    }
+    } /* if */
 
     return 1;
-  }
+  } /* if */
 
   int final_len = lenstr + lensub; /* length after insertion */
 
@@ -589,14 +589,14 @@ static cell AMX_NATIVE_CALL n_strins(AMX* amx, const cell* params)
       c = *ptr;
       ptr = packedptr(cstr, count);
       *ptr = (unsigned char)c;
-    }
+    } /* for */
 
     /* copy in the new characters */
     for (count = 0; count < lensub; count++) {
       c = extractchar(csub, count, 0);
       ptr = packedptr(cstr, index + count);
       *ptr = (unsigned char)c;
-    }
+    } /* for */
     *(packedptr(cstr, maxlen)) = 0;
   } else {
     /* make room for the new characters */
@@ -607,9 +607,9 @@ static cell AMX_NATIVE_CALL n_strins(AMX* amx, const cell* params)
     for (count = 0; count < lensub; count++) {
       c = extractchar(csub, count, 0);
       cstr[index + count] = c;
-    }
+    } /* for */
     cstr[maxlen] = 0;
-  }
+  } /* if */
 
   return 1;
 }


### PR DESCRIPTION
The changes are made in Pawn VM only (not in the compiler):
1. Fix a bug in `memcpy` function: the change was made in [this commit](https://github.com/openmultiplayer/compiler/commit/78380848c61506d81ca07c33752be9ef1874653c), so now offset is applied to `source` instead of `dest`. This way, the function `memcpy` in omp server still have bounds checking for destination array only, and we could be reading out of bounds from the source array if we set invalid `index` parameter
2. Fix indentation inside `strins` function. There should be 2 spaces instead of 4 like everywhere else
3. Re-add missed comment inside `flength` which was in original repo previously, fix typo in comment for "PAWN_CELL_SIZE 64"
4. Minor format fixes of the recently changed stuff to match the general style

Most of format tweaks were made on purpose, to reduce unnecessary differences in diff checker when comparing it with other forks based on original Pawn repo.