### PR TITLE
Ability to build pawn compiler with clang

### DIFF
--- a/source/compiler/libpawnc.def
+++ b/source/compiler/libpawnc.def
@@ -1,5 +1,4 @@
 LIBRARY       PAWNC
-DESCRIPTION   'Pawn compiler'
 
 EXPORTS Compile
         pc_compile


### PR DESCRIPTION
The purpose to have pawn compiler binaries built with clang on windows instead of msvc is to be in line with open.mp server and amx vm it uses: it's all built with clang now, but except the pawn compiler.

Before this change, trying to build pawn compiler with clang instead of msvc, this error appeared:

```
lld-link : error : unknown directive: DESCRIPTION
```

We could also remove Borland-specific files like .def.borland and .lbc since we don't need them anyway...